### PR TITLE
Fix the proposed -fno-exceptions support.

### DIFF
--- a/mingw.condition_variable.h
+++ b/mingw.condition_variable.h
@@ -75,12 +75,12 @@ public:
         :   mSemaphore(CreateSemaphore(NULL, 0, 0xFFFF, NULL))
     {
         if (mSemaphore == NULL)
-            mingw_throw_system_error_arg(GetLastError(), std::generic_category());
+            throw_error<std::system_error>(GetLastError(), std::generic_category());
         mWakeEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
         if (mWakeEvent == NULL)
         {
             CloseHandle(mSemaphore);
-            mingw_throw_system_error_arg(GetLastError(), std::generic_category());
+            throw_error<std::system_error>(GetLastError(), std::generic_category());
         }
     }
     ~condition_variable_any()
@@ -120,7 +120,7 @@ private:
         else
         {
             using namespace std;
-            mingw_throw_system_error(mingw_make_error_code(errc::protocol_error));
+            throw_error<std::system_error>(make_error_code(errc::protocol_error));
         }
 		return false;
     }

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -174,7 +174,7 @@ struct FutureBase : public FutureStatic<true>
   {
 #if !defined(NDEBUG)
     if (!valid())
-      mingw_throw_future_error(future_errc::no_state);
+      throw_error<future_error>(future_errc::no_state);
 #endif
 //    If there's already a value or exception, don't do any extraneous
 //  synchronization. The `get()` method will do that for us.
@@ -190,7 +190,7 @@ struct FutureBase : public FutureStatic<true>
   {
 #if !defined(NDEBUG)
     if (!valid())
-      mingw_throw_future_error(future_errc::no_state);
+      throw_error<future_error>(future_errc::no_state);
 #endif
     auto current_state = mState->mType.load(std::memory_order_relaxed);
     if (current_state & kReadyFlag)
@@ -465,9 +465,9 @@ class promise : mingw_stdthread::detail::FutureBase
   void check_before_set (void) const
   {
     if (!valid())
-      mingw_throw_future_error(future_errc::no_state);
+      mingw_stdthread::throw_error<future_error>(future_errc::no_state);
     if (mState->mType.load(std::memory_order_relaxed) & kSetFlag)
-      mingw_throw_future_error(future_errc::promise_already_satisfied);
+      mingw_stdthread::throw_error<future_error>(future_errc::promise_already_satisfied);
   }
 
   void check_abandon (void)
@@ -489,11 +489,13 @@ class promise : mingw_stdthread::detail::FutureBase
                                    FALSE, //  No need for this to be inherited.
                                    DUPLICATE_SAME_ACCESS | DUPLICATE_CLOSE_SOURCE);
     if (!success)
-      mingw_throw_runtime_error("MinGW STD Threads library failed to make a promise ready after thread exit.");
+      mingw_stdthread::throw_error<std::runtime_error>("MinGW STD Threads library failed to make a promise ready after thread exit.");
 
     mState->increment_references();
     bool handle_handled = false;
+#if !MINGW_STDTHREAD_NO_EXCEPTIONS
     try {
+#endif
       state_type * ptr = static_cast<state_type *>(mState);
       mingw_stdthread::thread watcher_thread ([ptr, thread_handle, &handle_handled](void)
         {
@@ -522,24 +524,27 @@ class promise : mingw_stdthread::detail::FutureBase
           });
       }
       watcher_thread.detach();
+#if !MINGW_STDTHREAD_NO_EXCEPTIONS
     }
     catch (...)
     {
 //    Because the original promise is still alive, this can't be the decrement
-//  destroys it.
+//  that destroys it.
       mState->decrement_references();
       if (!handle_handled)
         CloseHandle(thread_handle);
+      mingw_stdthread::throw_error<std::runtime_error>("MinGW STD Threads library failed to make a promise ready after thread exit.");
     }
+#endif
   }
 
   template<class U>
   future<U> make_future (void)
   {
     if (!valid())
-      mingw_throw_future_error(future_errc::no_state);
+      mingw_stdthread::throw_error<future_error>(future_errc::no_state);
     if (mRetrieved)
-      mingw_throw_future_error(future_errc::future_already_retrieved);
+      mingw_stdthread::throw_error<future_error>(future_errc::future_already_retrieved);
     mState->increment_references();
     mRetrieved = true;
     return future<U>(static_cast<state_type *>(mState));
@@ -923,11 +928,15 @@ struct StorageHelper
   template<class Func, class ... Args>
   static void store_deferred (FutureState<Ret> * state_ptr, Func && func, Args&&... args)
   {
+#if MINGW_STDTHREAD_NO_EXCEPTIONS
+    state_ptr->set_value(invoke(std::forward<Func>(func), std::forward<Args>(args)...));
+#else
     try {
       state_ptr->set_value(invoke(std::forward<Func>(func), std::forward<Args>(args)...));
     } catch (...) {
       state_ptr->set_exception(std::current_exception());
     }
+#endif
   }
   template<class Func, class ... Args>
   static void store (FutureState<Ret> * state_ptr, Func && func, Args&&... args)
@@ -946,13 +955,18 @@ struct StorageHelper<Ref&>
   template<class Func, class ... Args>
   static void store_deferred (FutureState<void*> * state_ptr, Func && func, Args&&... args)
   {
+    using Ref_non_cv = typename std::remove_cv<Ref>::type;
+#if MINGW_STDTHREAD_NO_EXCEPTIONS
+    Ref & rf = invoke(std::forward<Func>(func), std::forward<Args>(args)...);
+    state_ptr->set_value(const_cast<Ref_non_cv *>(std::addressof(rf)));
+#else
     try {
-      using Ref_non_cv = typename std::remove_cv<Ref>::type;
       Ref & rf = invoke(std::forward<Func>(func), std::forward<Args>(args)...);
       state_ptr->set_value(const_cast<Ref_non_cv *>(std::addressof(rf)));
     } catch (...) {
       state_ptr->set_exception(std::current_exception());
     }
+#endif
   }
   template<class Func, class ... Args>
   static void store (FutureState<void*> * state_ptr, Func && func, Args&&... args)
@@ -971,12 +985,17 @@ struct StorageHelper<void>
   template<class Func, class ... Args>
   static void store_deferred (FutureState<Empty> * state_ptr, Func && func, Args&&... args)
   {
+#if MINGW_STDTHREAD_NO_EXCEPTIONS
+    invoke(std::forward<Func>(func), std::forward<Args>(args)...);
+    state_ptr->set_value(Empty{});
+#else
     try {
       invoke(std::forward<Func>(func), std::forward<Args>(args)...);
       state_ptr->set_value(Empty{});
     } catch (...) {
       state_ptr->set_exception(std::current_exception());
     }
+#endif
   }
   template<class Func, class ... Args>
   static void store (FutureState<Empty> * state_ptr, Func && func, Args&&... args)

--- a/mingw.future.h
+++ b/mingw.future.h
@@ -473,13 +473,7 @@ class promise : mingw_stdthread::detail::FutureBase
   void check_abandon (void)
   {
     if (valid() && !(mState->mType.load(std::memory_order_relaxed) & kSetFlag))
-    {
-      try {
-        mingw_throw_future_error(future_errc::broken_promise);
-      } catch (...) {
-        set_exception(std::current_exception());
-      }
-    }
+      set_exception(std::make_exception_ptr(future_error(future_errc::broken_promise)));
   }
 /// \bug Might throw more exceptions than specified by the standard...
 //  Need OS support for this...
@@ -953,7 +947,7 @@ struct StorageHelper<Ref&>
   static void store_deferred (FutureState<void*> * state_ptr, Func && func, Args&&... args)
   {
     try {
-      typedef typename std::remove_cv<Ref>::type Ref_non_cv;
+      using Ref_non_cv = typename std::remove_cv<Ref>::type;
       Ref & rf = invoke(std::forward<Func>(func), std::forward<Args>(args)...);
       state_ptr->set_value(const_cast<Ref_non_cv *>(std::addressof(rf)));
     } catch (...) {

--- a/mingw.mutex.h
+++ b/mingw.mutex.h
@@ -120,7 +120,7 @@ struct _OwnerThread
         fprintf(stderr, "FATAL: Recursive locking of non-recursive mutex\
  detected. Throwing system exception\n");
         fflush(stderr);
-        mingw_throw_system_error(mingw_make_error_code(errc::resource_deadlock_would_occur));
+        throw_error<std::system_error>(make_error_code(errc::resource_deadlock_would_occur));
     }
     DWORD checkOwnerBeforeLock() const
     {
@@ -341,13 +341,13 @@ public:
 #endif
         if ((ret != WAIT_OBJECT_0) && (ret != WAIT_ABANDONED))
         {
-            mingw_throw_system_error_arg(GetLastError(), std::system_category());
+            throw_error<std::system_error>(GetLastError(), std::system_category());
         }
     }
     void unlock()
     {
         if (!ReleaseMutex(mHandle))
-            mingw_throw_system_error_arg(GetLastError(), std::system_category());
+            throw_error<std::system_error>(GetLastError(), std::system_category());
     }
     bool try_lock()
     {

--- a/mingw.shared_mutex.h
+++ b/mingw.shared_mutex.h
@@ -130,7 +130,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (!(mCounter.fetch_sub(1, memory_order_release) & static_cast<counter_type>(~kWriteBit)))
-            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
+            throw_error<system_error>(make_error_code(errc::operation_not_permitted));
 #else
         mCounter.fetch_sub(1, memory_order_release);
 #endif
@@ -183,7 +183,7 @@ public:
         using namespace std;
 #ifndef NDEBUG
         if (mCounter.load(memory_order_relaxed) != kWriteBit)
-            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
+            throw_error<system_error>(make_error_code(errc::operation_not_permitted));
 #endif
         mCounter.store(0, memory_order_release);
     }
@@ -313,9 +313,9 @@ class shared_lock
     {
         using namespace std;
         if (mMutex == nullptr)
-            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
+            throw_error<system_error>(make_error_code(errc::operation_not_permitted));
         if (mOwns)
-            mingw_throw_system_error(mingw_make_error_code(errc::resource_deadlock_would_occur));
+            throw_error<system_error>(make_error_code(errc::resource_deadlock_would_occur));
     }
 public:
     typedef Mutex mutex_type;
@@ -428,7 +428,7 @@ public:
     {
         using namespace std;
         if (!mOwns)
-            mingw_throw_system_error(mingw_make_error_code(errc::operation_not_permitted));
+            throw_error<system_error>(make_error_code(errc::operation_not_permitted));
         mMutex->unlock_shared();
         mOwns = false;
     }

--- a/mingw.thread.h
+++ b/mingw.thread.h
@@ -266,7 +266,7 @@ public:
             int errnum = errno;
             delete call;
 //  Note: Should only throw EINVAL, EAGAIN, EACCES
-            mingw_throw_system_error_arg(errnum, std::generic_category());
+            throw_error<std::system_error>(errnum, std::generic_category());
         } else
             mHandle = reinterpret_cast<HANDLE>(int_handle);
     }
@@ -281,11 +281,11 @@ public:
     {
         using namespace std;
         if (get_id() == id(GetCurrentThreadId()))
-            mingw_throw_system_error(mingw_make_error_code(errc::resource_deadlock_would_occur));
+            throw_error<system_error>(make_error_code(errc::resource_deadlock_would_occur));
         if (mHandle == kInvalidHandle)
-            mingw_throw_system_error(mingw_make_error_code(errc::no_such_process));
+            throw_error<system_error>(make_error_code(errc::no_such_process));
         if (!joinable())
-            mingw_throw_system_error(mingw_make_error_code(errc::invalid_argument));
+            throw_error<system_error>(make_error_code(errc::invalid_argument));
         WaitForSingleObject(mHandle, INFINITE);
         CloseHandle(mHandle);
         mHandle = kInvalidHandle;
@@ -334,7 +334,7 @@ moving another thread to it.\n");
         if (!joinable())
         {
             using namespace std;
-            mingw_throw_system_error(mingw_make_error_code(errc::invalid_argument));
+            throw_error<std::system_error>(make_error_code(errc::invalid_argument));
         }
         if (mHandle != kInvalidHandle)
         {

--- a/mingw.throw.h
+++ b/mingw.throw.h
@@ -23,33 +23,36 @@
 #if !defined(__cplusplus) || (__cplusplus < 201103L)
 #error A C++11 compiler is required!
 #endif
-	
+
 // (Multi args version)
 //#define mingw_throw_multi(_1,_2,NAME,...) NAME
 //#define mingw_throw_system_error(...) mingw_throw_multi(__VA_ARGS__,  mingw_throw_system_error2, mingw_throw_system_error1)(__VA_ARGS__)
 
-	
-#ifdef __cpp_exceptions
+//    Disabling exceptions is very much non-standard behavior. Though C++20 may
+//  add a feature-test macro, earlier versions do not provide such a mechanism.
+//  Instead, appropriate compiler-specific macros must be checked.
+#if (defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)) || \
+  defined(__EXCEPTIONS) || (!defined(__clang__) && !defined(__GNUC__))
 
 	#define mingw_make_error_code(err) 			     std::make_error_code(err)
 
 	#define mingw_throw_system_error(err)   	     throw std::system_error(err)
 	#define mingw_throw_system_error_arg(err, arg)   throw std::system_error(err, arg)
-	
+
 	#define mingw_throw_future_error(err)   	     throw std::future_error(err)
 	#define mingw_throw_runtime_error(err)  	     throw std::runtime_error(err)
-	
+
 #else
-	
+
 	#define mingw_make_error_code(err) 			     int(err)
 
 	#define mingw_throw_system_error(err)   	     std::__throw_system_error(err)
 	#define mingw_throw_system_error_arg(err, arg)   std::__throw_system_error(err)
-	
+
 	#define mingw_throw_future_error(err)   	     std::__throw_future_error(err)
 	#define mingw_throw_runtime_error(err)  	     std::__throw_runtime_error(err)
-	
+
 #endif
-	
-	
+
+
 #endif // MINGW_THROW_H_

--- a/mingw.throw.h
+++ b/mingw.throw.h
@@ -24,35 +24,32 @@
 #error A C++11 compiler is required!
 #endif
 
-// (Multi args version)
-//#define mingw_throw_multi(_1,_2,NAME,...) NAME
-//#define mingw_throw_system_error(...) mingw_throw_multi(__VA_ARGS__,  mingw_throw_system_error2, mingw_throw_system_error1)(__VA_ARGS__)
+#if (defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)) || \
+  defined(__EXCEPTIONS) || (!defined(__clang__) && !defined(__GNUC__))
+#define MINGW_STDTHREAD_NO_EXCEPTIONS 0
+#else
+#define MINGW_STDTHREAD_NO_EXCEPTIONS 1
+#endif
 
 //    Disabling exceptions is very much non-standard behavior. Though C++20 may
 //  add a feature-test macro, earlier versions do not provide such a mechanism.
 //  Instead, appropriate compiler-specific macros must be checked.
-#if (defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)) || \
-  defined(__EXCEPTIONS) || (!defined(__clang__) && !defined(__GNUC__))
-
-	#define mingw_make_error_code(err) 			     std::make_error_code(err)
-
-	#define mingw_throw_system_error(err)   	     throw std::system_error(err)
-	#define mingw_throw_system_error_arg(err, arg)   throw std::system_error(err, arg)
-
-	#define mingw_throw_future_error(err)   	     throw std::future_error(err)
-	#define mingw_throw_runtime_error(err)  	     throw std::runtime_error(err)
-
+namespace mingw_stdthread
+{
+#if MINGW_STDTHREAD_NO_EXCEPTIONS
+template<class T, class ... Args>
+inline void throw_error (Args&&...)
+{
+  std::abort();
+}
 #else
-
-	#define mingw_make_error_code(err) 			     int(err)
-
-	#define mingw_throw_system_error(err)   	     std::__throw_system_error(err)
-	#define mingw_throw_system_error_arg(err, arg)   std::__throw_system_error(err)
-
-	#define mingw_throw_future_error(err)   	     std::__throw_future_error(err)
-	#define mingw_throw_runtime_error(err)  	     std::__throw_runtime_error(err)
-
+template<class T, class ... Args>
+inline void throw_error (Args&&... args)
+{
+  throw T(std::forward<Args>(args)...);
+}
 #endif
+}
 
 
 #endif // MINGW_THROW_H_

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -141,28 +141,22 @@ void test_future ()
   future<T> future_broken = promise_broken.get_future();
   future<T> future_late = promise_late.get_future();
 
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
   try {
     future<T> impossible_future = promise_value.get_future();
     log("WARNING: Promise failed to detect that its future was already retrieved.");
   } catch(...) {
     log("\tPromise successfully prevented redundant future retrieval.");
   }
+#endif
 
   log("\tPassing promises to a new thread...");
   thread t ([](promise<T> p_value, promise<T> p_exception, promise<T>, promise<T> p_late)
     {
       this_thread::sleep_for(std::chrono::seconds(1));
-      try {
-        throw std::runtime_error("Thrown during the thread.");
-      } catch (...) {
-        p_late.set_exception_at_thread_exit(std::current_exception());
-      }
+      p_late.set_exception_at_thread_exit(std::make_exception_ptr(std::runtime_error("Thrown during the thread.")));
       test_future_set_value(p_value);
-      try {
-        throw std::runtime_error("Things happened as expected.");
-      } catch (...) {
-        p_exception.set_exception(std::current_exception());
-      }
+      p_exception.set_exception(std::make_exception_ptr(std::runtime_error("Things happened as expected.")));
       this_thread::sleep_for(std::chrono::seconds(2));
     },
     std::move(promise_value),
@@ -171,9 +165,12 @@ void test_future ()
     std::move(promise_late));
   t.detach();
 
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
   try {
+#endif
     bool was_expected = test_future_get_value(future_value);
     log("\tReceived %sexpected value.", (was_expected ? "" : "un"));
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
   } catch (...) {
     log("WARNING: Exception where there should be none!");
     throw;
@@ -184,8 +181,10 @@ void test_future ()
   } catch (std::exception & e) {
     log("\tReceived an exception (\"%s\") as expected.", e.what());
   }
+#endif
 
   log("\tWaiting for the thread to exit...");
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
   try {
     test_future_get_value(future_late);
     log("WARNING: Got a value where there should be an exception!");
@@ -199,6 +198,7 @@ void test_future ()
   } catch (std::future_error & e) {
     log("\tReceived a future_error (\"%s\") as expected.", e.what());
   }
+#endif
 
   log("\tDeferring a function...");
   auto async_deferred = async(launch::deferred, [] (void) -> T
@@ -314,7 +314,9 @@ int main()
     }
     std::thread t([](TestMove&& a, const char* b, int c) mutable
     {
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
         try
+#endif
         {
             log("Worker thread started, sleeping for a while...");
 //  Thread might move the string more than once.
@@ -348,13 +350,17 @@ int main()
 
             log("Worker thread finishing");
         }
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
         catch(std::exception& e)
         {
             printf("EXCEPTION in worker thread: %s\n", e.what());
         }
+#endif
     },
     TestMove("move test"), "test message", -20);
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
     try
+#endif
     {
       log("Main thread: Locking mutex, waiting on condvar...");
       {
@@ -383,10 +389,12 @@ int main()
       log("Main thread: Worker thread joined");
       fflush(stdout);
     }
+#if defined(__cpp_exceptions) && (__cpp_exceptions >= 199711L)
     catch(std::exception& e)
     {
         log("EXCEPTION in main thread: %s", e.what());
     }
+#endif
     once_flag of;
     call_once(of, test_call_once, 1, "test");
     call_once(of, test_call_once, 1, "ERROR! Should not be called second time");


### PR DESCRIPTION
Fixes a variety of errors that remain when compiling with `-fno-exceptions` enabled, removes some dangerously-named macros in favor of function templates (a macro is usually expected to be defined using a `CAPITALS_AND_UNDERSCORES` name), removes the unnecessary macro `mingw_make_error_code` (because `std::make_error_code` remains functional with `-fno-exceptions`), and alters `promise` such that it no longer uses `try { throw ... } catch {}` to store known exceptions (instead using `std::make_exception_ptr`).

Some tasks remain, for full `-fno-exceptions` support:
- In every case of throwing an exception, decide the ideal behavior that ought to replace it.
- Find appropriate macros for Visual Studio disabled-exception detection.